### PR TITLE
Added smart_path option for file name getters.

### DIFF
--- a/lua/telescope/builtin/lsp.lua
+++ b/lua/telescope/builtin/lsp.lua
@@ -14,8 +14,6 @@ local conf = require('telescope.config').values
 local lsp = {}
 
 lsp.references = function(opts)
-  opts.shorten_path = utils.get_default(opts.shorten_path, true)
-
   local params = vim.lsp.util.make_position_params()
   params.context = { includeDeclaration = true }
 
@@ -243,8 +241,6 @@ lsp.range_code_actions = function(opts)
 end
 
 lsp.workspace_symbols = function(opts)
-  opts.shorten_path = utils.get_default(opts.shorten_path, true)
-
   local params = {query = opts.query or ''}
   local results_lsp, err = vim.lsp.buf_request_sync(0, "workspace/symbol", params, opts.timeout or 10000)
   if err then

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -118,6 +118,7 @@ function config.set_defaults(defaults)
   set(types.path_display_options.HIDE_PATH, false)
   set(types.path_display_options.SHORTEN_PATH, false)
   set(types.path_display_options.TAIL_PATH, false)
+  set(types.path_display_options.SMART_PATH, false)
 
   set("get_status_text", function(self)
     local xx = (self.stats.processed or 0) - (self.stats.filtered or 0)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -1,3 +1,5 @@
+local types = require('telescope.types')
+
 -- Keep the values around between reloads
 _TelescopeConfigurationValues = _TelescopeConfigurationValues or {}
 
@@ -113,9 +115,9 @@ function config.set_defaults(defaults)
   set("border", {})
   set("borderchars", { '─', '│', '─', '│', '╭', '╮', '╯', '╰'})
 
-  set("hide_filename", false)
-  set("shorten_path", false)
-  set("tail_path", false)
+  set(types.path_display_options.HIDE_PATH, false)
+  set(types.path_display_options.SHORTEN_PATH, false)
+  set(types.path_display_options.TAIL_PATH, false)
 
   set("get_status_text", function(self)
     local xx = (self.stats.processed or 0) - (self.stats.filtered or 0)

--- a/lua/telescope/config.lua
+++ b/lua/telescope/config.lua
@@ -113,6 +113,10 @@ function config.set_defaults(defaults)
   set("border", {})
   set("borderchars", { '─', '│', '─', '│', '╭', '╮', '╯', '╰'})
 
+  set("hide_filename", false)
+  set("shorten_path", false)
+  set("tail_path", false)
+
   set("get_status_text", function(self)
     local xx = (self.stats.processed or 0) - (self.stats.filtered or 0)
     local yy = self.stats.processed or 0

--- a/lua/telescope/types.lua
+++ b/lua/telescope/types.lua
@@ -1,0 +1,23 @@
+local types = {}
+
+-- convert numbered index table into an enum
+--
+-- example:
+-- enum { "foo", "bar" }
+-- returns:
+-- { foo = 1, bar = 2 }
+local enum = function(table)
+  for i = 1, #table do
+    table[table[i]] = i
+    table[i] = nil
+  end
+  return table
+end
+
+types.path_display_options = enum {
+  "HIDE_PATH",
+  "SHORTEN_PATH",
+  "TAIL_PATH"
+}
+
+return types

--- a/lua/telescope/types.lua
+++ b/lua/telescope/types.lua
@@ -6,18 +6,16 @@ local types = {}
 -- enum { "foo", "bar" }
 -- returns:
 -- { foo = 1, bar = 2 }
+-- these are going to be option names. to enable, add <option> = true
+local paths = {"hide_path", "shorten_path", "tail_path", "smart_path"}
 local enum = function(table)
   for i = 1, #table do
-    table[table[i]] = i
-    table[i] = nil
+      table[table[i]] = paths[i]
+      table[i] = nil
   end
   return table
 end
 
-types.path_display_options = enum {
-  "HIDE_PATH",
-  "SHORTEN_PATH",
-  "TAIL_PATH"
-}
+types.path_display_options = enum {"HIDE_PATH", "SHORTEN_PATH", "TAIL_PATH", "SMART_PATH"}
 
 return types

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -147,6 +147,29 @@ utils.path_tail = (function()
   end
 end)()
 
+utils.transform_filepath = function(opts, path)
+  local config = require('telescope.config').values
+
+  if path == nil or utils.get_default(opts.hide_filename, config.hide_filename) then
+    return ''
+  end
+
+  local transformed_path = path
+
+  if utils.get_default(opts.tail_path, config.tail_path) then
+    transformed_path = utils.path_tail(transformed_path)
+  else
+    local cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd())
+    transformed_path = pathlib.make_relative(transformed_path, cwd)
+
+    if utils.get_default(opts.shorten_path, config.shorten_path) then
+      transformed_path = pathlib.shorten(transformed_path)
+    end
+  end
+
+  return transformed_path
+end
+
 -- local x = utils.make_default_callable(function(opts)
 --   return function()
 --     print(opts.example, opts.another)

--- a/lua/telescope/utils.lua
+++ b/lua/telescope/utils.lua
@@ -2,6 +2,7 @@ local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
 
 local pathlib = require('telescope.path')
 local Job     = require('plenary.job')
+local types   = require('telescope.types')
 
 local utils = {}
 
@@ -149,20 +150,21 @@ end)()
 
 utils.transform_filepath = function(opts, path)
   local config = require('telescope.config').values
+  local types = types.path_display_options
 
-  if path == nil or utils.get_default(opts.hide_filename, config.hide_filename) then
+  if path == nil or utils.get_default(opts[types.HIDE_PATH], config[types.HIDE_PATH]) then
     return ''
   end
 
   local transformed_path = path
 
-  if utils.get_default(opts.tail_path, config.tail_path) then
+  if utils.get_default(opts[types.TAIL_PATH], config[types.TAIL_PATH]) then
     transformed_path = utils.path_tail(transformed_path)
   else
     local cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd())
     transformed_path = pathlib.make_relative(transformed_path, cwd)
 
-    if utils.get_default(opts.shorten_path, config.shorten_path) then
+    if utils.get_default(opts[types.SHORTEN_PATH], config[types.SHORTEN_PATH]) then
       transformed_path = pathlib.shorten(transformed_path)
     end
   end


### PR DESCRIPTION
https://github.com/tom-anders/telescope-vim-bookmarks.nvim/pull/2

Hey!

So I've done this after the discussion with @Conni2461 and how this would overall benefit the project. 

Placing myself at mercy, I've also decided to change the enum logic as well. So that a user doesn't have to deal with importing/exporting/creating enums but configure the options as it is (ie. smart_path = true)

Just to have the preview here as well:

![Screenshot 2021-05-24 at 13 21 28](https://user-images.githubusercontent.com/11707431/119340566-f6fdb000-bc92-11eb-9ffa-45676412d478.png)

Let me know what you think!